### PR TITLE
Update PennyLane benchmarks

### DIFF
--- a/pennylane/benchmarks.py
+++ b/pennylane/benchmarks.py
@@ -26,7 +26,6 @@ class QFT:
                 operations.append(qml.SWAP(wires=[i, self.n - i - 1]))
 
             self.dev.apply(operations)
-            #return qml.probs(wires=range(self.n))
 
         return apply_qft_circuit()
 

--- a/pennylane/benchmarks.py
+++ b/pennylane/benchmarks.py
@@ -104,7 +104,7 @@ class GateTest:
     def __call__(self):
         def apply_gate():
             operations = []
-            operations.append(gate(*self.args, wires=self.wires))
+            operations.append(self.gate(*self.args, wires=self.wires))
             self.dev.apply(operations)
 
         return apply_gate()

--- a/pennylane/benchmarks.py
+++ b/pennylane/benchmarks.py
@@ -13,18 +13,22 @@ class QFT:
         self.dev = qml.device(dev, wires=n)
 
     def __call__(self):
-        @qml.qnode(self.dev)
-        def qft_circuit():
+
+        def apply_qft_circuit():
+            operations = []
+
             for wire in reversed(range(self.n)):
-                qml.Hadamard(wire)
+                operations.append(qml.Hadamard(wire))
                 for i in range(wire):
-                    qml.CRZ(np.pi/(2**(wire-i)), wires=[i,wire])
+                    operations.append(qml.CRZ(np.pi/(2**(wire-i)), wires=[i,wire]))
 
             for i in range(self.n//2):
-                qml.SWAP(wires=[i, self.n - i - 1])
+                operations.append(qml.SWAP(wires=[i, self.n - i - 1]))
 
-            return qml.probs(wires=range(self.n))
-        return qft_circuit()
+            self.dev.apply(operations)
+            #return qml.probs(wires=range(self.n))
+
+        return apply_qft_circuit()
 
 
 class QCBM:
@@ -33,10 +37,10 @@ class QCBM:
         self.nlayers = nlayers
         self.neighbors = [(i, (i + 1) % n) for i in range(n)]
         self.dev = qml.device(dev, wires=n)
+        self.operations = []
 
     def __call__(self, vars):
-        @qml.qnode(self.dev)
-        def qcbm_circuit(vars):
+        def apply_qcbm_circuit(vars):
             self.first_layer(vars[1])
             for each in vars[2:-2]:
                 self.entangler()
@@ -45,9 +49,9 @@ class QCBM:
             self.entangler()
             self.last_layer(vars[-1])
 
-            return qml.expval(qml.PauliZ(0))
+            self.dev.apply(self.operations)
 
-        return qcbm_circuit(vars)
+        return apply_qcbm_circuit(vars)
 
     def generate_random_vars(self):
         vars = [np.random.rand(self.n, 2)]
@@ -55,21 +59,18 @@ class QCBM:
         vars += [np.random.rand(self.n, 2)]
         return vars
 
-    @staticmethod
-    def first_rotation(alpha, beta, wires=1):
-        qml.RX(alpha, wires=wires)
-        qml.RZ(beta, wires=wires)
+    def first_rotation(self, alpha, beta, wires=1):
+        self.operations.append(qml.RX(alpha, wires=wires))
+        self.operations.append(qml.RZ(beta, wires=wires))
 
-    @staticmethod
-    def mid_rotation(alpha, beta, gamma, wires=1):
-        qml.RZ(alpha, wires=wires)
-        qml.RX(beta, wires=wires)
-        qml.RZ(gamma, wires=wires)
+    def mid_rotation(self, alpha, beta, gamma, wires=1):
+        self.operations.append(qml.RZ(alpha, wires=wires))
+        self.operations.append(qml.RX(beta, wires=wires))
+        self.operations.append(qml.RZ(gamma, wires=wires))
 
-    @staticmethod
-    def last_rotation(alpha, beta, wires=1):
-        qml.RX(alpha, wires=wires)
-        qml.RZ(beta, wires=wires)
+    def last_rotation(self, alpha, beta, wires=1):
+        self.operations.append(qml.RX(alpha, wires=wires))
+        self.operations.append(qml.RZ(beta, wires=wires))
 
     def first_layer(self, vars):
         for each in vars:
@@ -85,7 +86,7 @@ class QCBM:
 
     def entangler(self):
         for i, j in self.neighbors:
-            qml.CNOT(wires=[i, j])
+            self.operations.append(qml.CNOT(wires=[i, j]))
 
 
 def _raise_exception(self):
@@ -97,16 +98,14 @@ class GateTest:
         self.n = n
         self.dev = qml.device(dev, wires=n)
 
-        # This ensures that no expectation values are calculated
-        # which would skew the results for gate tests
-        self.dev.pre_measure = _raise_exception
         self.gate = gate
         self.args = args
         self.wires = wires
 
     def __call__(self):
         def apply_gate():
-            operations = [gate(*self.args, wires=self.wires)]
+            operations = []
+            operations.append(gate(*self.args, wires=self.wires))
             self.dev.apply(operations)
 
         return apply_gate()

--- a/pennylane/benchmarks.py
+++ b/pennylane/benchmarks.py
@@ -88,10 +88,6 @@ class QCBM:
             self.operations.append(qml.CNOT(wires=[i, j]))
 
 
-def _raise_exception(self):
-    raise Exception()
-
-
 class GateTest:
     def __init__(self, n, gate, wires, dev="lightning.qubit", args=()):
         self.n = n
@@ -103,8 +99,7 @@ class GateTest:
 
     def __call__(self):
         def apply_gate():
-            operations = []
-            operations.append(self.gate(*self.args, wires=self.wires))
+            operations = [self.gate(*self.args, wires=self.wires)]
             self.dev.apply(operations)
 
         return apply_gate()

--- a/pennylane/benchmarks.py
+++ b/pennylane/benchmarks.py
@@ -8,7 +8,7 @@ import pytest
 
 
 class QFT:
-    def __init__(self, n, dev="default.qubit"):
+    def __init__(self, n, dev="lightning.qubit"):
         self.n = n
         self.dev = qml.device(dev, wires=n)
 
@@ -31,7 +31,7 @@ class QFT:
 
 
 class QCBM:
-    def __init__(self, n, nlayers, dev="default.qubit"):
+    def __init__(self, n, nlayers, dev="lightning.qubit"):
         self.n = n
         self.nlayers = nlayers
         self.neighbors = [(i, (i + 1) % n) for i in range(n)]
@@ -93,7 +93,7 @@ def _raise_exception(self):
 
 
 class GateTest:
-    def __init__(self, n, gate, wires, dev="default.qubit", args=()):
+    def __init__(self, n, gate, wires, dev="lightning.qubit", args=()):
         self.n = n
         self.dev = qml.device(dev, wires=n)
 

--- a/pennylane/benchmarks.py
+++ b/pennylane/benchmarks.py
@@ -105,18 +105,11 @@ class GateTest:
         self.wires = wires
 
     def __call__(self):
-        @qml.qnode(self.dev)
-        def gate_circuit():
-            self.gate(*self.args, wires=self.wires)
-            return qml.expval(qml.PauliZ(0))
+        def apply_gate():
+            operations = [gate(*self.args, wires=self.wires)]
+            self.dev.apply(operations)
 
-        def eval():
-            try:
-                gate_circuit()
-            except:
-                pass
-
-        return eval()
+        return apply_gate()
 
 
 nqubits_list = range(4,26)


### PR DESCRIPTION
Hi @Roger-luo, I've created a PR that updates how the Pennylane benchmarks are performed.

It changes two major parts:

## 1. The way how the benchmarks are performed

As it was discussed in https://github.com/yardstiq/quantum-benchmarks/pull/7, the way how PennyLane works is different to other quantum computing frameworks.

In PennyLane, the most common user interface involves both:

a) executing a quantum circuit on a device and
b) computing an expectation value (or some other quantity).

To make a fair comparison with other quantum computing frameworks, an error was added in #7 in an attempt to restrict the PennyLane execution pipeline to the device execution step. This approach, however, uses an outdated device API (the `pre_measure` method) and affects the benchmarking results.

The correct, up-to-date approach is to call the `apply` method of the device: this method applies the quantum operations defined in the circuit using the statevector of the device.

```python
import pennylane as qml

dev = qml.device('lightning.qubit', wires=1)

print("Statevector before applying any operations: ", dev.state)

operations = [qml.Hadamard(0)]
dev.apply(operations)

print("Statevector after applying the Hadamard gate: ", dev.state)
```
```
Statevector before applying any operations:  [1.+0.j 0.+0.j]
Statevector after applying the Hadamard gate:  [0.70710678+0.j 0.70710678+0.j]
```

## 2. The device used

A more performant device called `lightning.qubit` has been included in the PennyLane ecosystem and is available to users when installing [PennyLane >v0.18.0](https://github.com/PennyLaneAI/pennylane/releases/tag/v0.18.0). The benchmarks were updated such that they use this device.

By issuing `pip install pennylane`, the device is available via `qml.device("lightning.qubit", wires=number_of_qubits)`.

----

Let me know if any further changes or details would be required to have these changes in. Thank you!