### PR TITLE
Qrack (strictly "ket")

### DIFF
--- a/qrack/benchmarks.cc
+++ b/qrack/benchmarks.cc
@@ -9,9 +9,14 @@ using namespace Qrack;
 auto min_estimator = [](const std::vector<double>& v) -> double {return *(std::min_element(std::begin(v), std::end(v)));};
 
 static void BM_sim_X(benchmark::State& state) {
+	QInterfacePtr qReg = NULL; 
 	for (auto _ : state){
-		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+		if (qReg != NULL){
+			qReg.reset();
+		}
+		qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0); 
 		qReg->X(state.range(0) - 1);
+		qReg->Finish();
 	}
 	state.SetLabel("X");
 }
@@ -19,8 +24,8 @@ static void BM_sim_X(benchmark::State& state) {
 BENCHMARK(BM_sim_X)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_H(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 	for (auto _ : state){
-		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 		qReg->H(state.range(0) - 1);
 	}
 	state.SetLabel("H");
@@ -29,8 +34,8 @@ static void BM_sim_H(benchmark::State& state) {
 BENCHMARK(BM_sim_H)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_T(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 	for (auto _ : state){
-		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 		qReg->T(state.range(0) - 1);
 	}
 	state.SetLabel("T");
@@ -39,8 +44,8 @@ static void BM_sim_T(benchmark::State& state) {
 BENCHMARK(BM_sim_T)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_CNOT(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 	for (auto _ : state){
-		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 		qReg->CNOT(0,1);
 	}
 	state.SetLabel("CNOT");
@@ -49,8 +54,8 @@ static void BM_sim_CNOT(benchmark::State& state) {
 BENCHMARK(BM_sim_CNOT)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Toffoli(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 	for (auto _ : state){
-		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 		qReg->CCNOT(0,1,2);
 	}
 	state.SetLabel("Toffoli");
@@ -59,8 +64,8 @@ static void BM_sim_Toffoli(benchmark::State& state) {
 BENCHMARK(BM_sim_Toffoli)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Rx(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 	for (auto _ : state){
-		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 		qReg->RX(0.5, 2);
 	}
 	state.SetLabel("Rx");
@@ -69,8 +74,8 @@ static void BM_sim_Rx(benchmark::State& state) {
 BENCHMARK(BM_sim_Rx)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Ry(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 	for (auto _ : state){
-		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
 		qReg->RY(0.5, 2);
 	}
 	state.SetLabel("Ry");

--- a/qrack/benchmarks.cc
+++ b/qrack/benchmarks.cc
@@ -1,0 +1,95 @@
+#include <benchmark/benchmark.h>
+#include "qrack/qfactory.hpp"
+
+#include <algorithm>
+#include <iostream>
+
+using namespace Qrack; 
+
+auto min_estimator = [](const std::vector<double>& v) -> double {return *(std::min_element(std::begin(v), std::end(v)));};
+
+static void BM_sim_X(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	qReg->X(state.range(0) - 1);
+
+	for (auto _ : state){
+		qReg->M(state.range(0) - 1);
+	}
+	state.SetLabel("X");
+}
+// Register the function as a benchmark
+BENCHMARK(BM_sim_X)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+
+static void BM_sim_H(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	qReg->H(state.range(0) - 1);
+
+	for (auto _ : state){
+		qReg->M(state.range(0) - 1);
+	}
+	state.SetLabel("H");
+}
+// Register the function as a benchmark
+BENCHMARK(BM_sim_H)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+
+static void BM_sim_T(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	qReg->T(state.range(0) - 1);
+
+	for (auto _ : state){
+		qReg->M(state.range(0) - 1);
+	}
+	state.SetLabel("T");
+}
+// Register the function as a benchmark
+BENCHMARK(BM_sim_T)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+
+static void BM_sim_CNOT(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	qReg->CNOT(0,1);
+
+	for (auto _ : state){
+		qReg->M(1);
+	}
+	state.SetLabel("CNOT");
+}
+// Register the function as a benchmark
+BENCHMARK(BM_sim_CNOT)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+
+static void BM_sim_Toffoli(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	qReg->CCNOT(0,1,2);
+
+	for (auto _ : state){
+		qReg->M(1);
+	}
+	state.SetLabel("Toffoli");
+}
+// Register the function as a benchmark
+BENCHMARK(BM_sim_Toffoli)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+
+static void BM_sim_Rx(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	qReg->RX(0.5, 2);
+
+	for (auto _ : state){
+		qReg->M(2);
+	}
+	state.SetLabel("Rx");
+}
+// Register the function as a benchmark
+BENCHMARK(BM_sim_Rx)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+
+static void BM_sim_Ry(benchmark::State& state) {
+	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	qReg->RY(0.5, 2);
+
+	for (auto _ : state){
+		qReg->M(2);
+	}
+	state.SetLabel("Ry");
+}
+// Register the function as a benchmark
+BENCHMARK(BM_sim_Ry)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+
+BENCHMARK_MAIN();

--- a/qrack/benchmarks.cc
+++ b/qrack/benchmarks.cc
@@ -9,87 +9,73 @@ using namespace Qrack;
 auto min_estimator = [](const std::vector<double>& v) -> double {return *(std::min_element(std::begin(v), std::end(v)));};
 
 static void BM_sim_X(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
-	qReg->X(state.range(0) - 1);
-
 	for (auto _ : state){
-		qReg->M(state.range(0) - 1);
+		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+		qReg->X(state.range(0) - 1);
 	}
 	state.SetLabel("X");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_X)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_X)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_H(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
-	qReg->H(state.range(0) - 1);
-
 	for (auto _ : state){
-		qReg->M(state.range(0) - 1);
+		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+		qReg->H(state.range(0) - 1);
 	}
 	state.SetLabel("H");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_H)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_H)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_T(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
-	qReg->T(state.range(0) - 1);
-
 	for (auto _ : state){
-		qReg->M(state.range(0) - 1);
+		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+		qReg->T(state.range(0) - 1);
 	}
 	state.SetLabel("T");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_T)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_T)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_CNOT(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
-	qReg->CNOT(0,1);
-
 	for (auto _ : state){
-		qReg->M(1);
+		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+		qReg->CNOT(0,1);
 	}
 	state.SetLabel("CNOT");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_CNOT)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_CNOT)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Toffoli(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
-	qReg->CCNOT(0,1,2);
-
 	for (auto _ : state){
-		qReg->M(1);
+		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+		qReg->CCNOT(0,1,2);
 	}
 	state.SetLabel("Toffoli");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_Toffoli)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_Toffoli)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Rx(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
-	qReg->RX(0.5, 2);
-
 	for (auto _ : state){
-		qReg->M(2);
+		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+		qReg->RX(0.5, 2);
 	}
 	state.SetLabel("Rx");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_Rx)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_Rx)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Ry(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
-	qReg->RY(0.5, 2);
-
 	for (auto _ : state){
-		qReg->M(2);
+		QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+		qReg->RY(0.5, 2);
 	}
 	state.SetLabel("Ry");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_Ry)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_Ry)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 BENCHMARK_MAIN();

--- a/qrack/benchmarks.cc
+++ b/qrack/benchmarks.cc
@@ -82,7 +82,50 @@ static void BM_sim_Ry(benchmark::State& state) {
 	qReg->Finish();
 	state.SetLabel("Ry");
 }
+
 // Register the function as a benchmark
 BENCHMARK(BM_sim_Ry)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
+
+static void BM_sim_QCBM(benchmark::State& state) {
+        QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
+        for (auto _: state){
+
+               // First rotation
+               for (int i = 0; i < qReg->GetQubitCount(); i++) {
+                       qReg->RX(qReg->Rand(), i);
+                       qReg->RZ(qReg->Rand(), i);
+               }
+
+		// Entangler
+               for (int i = 0; i < qReg->GetQubitCount(); i++) {
+                       qReg->CNOT(i, (i+1) % qReg->GetQubitCount());
+               }
+
+
+		for (int depth = 0; depth < 9; depth++){
+			// Mid Rotation
+			for (int i = 0; i < qReg->GetQubitCount(); i++) {
+			        qReg->RZ(qReg->Rand(), i);
+                               qReg->RX(qReg->Rand(), i);
+                               qReg->RZ(qReg->Rand(), i);
+                       }
+
+			// Entangler
+                       for (int i = 0; i < qReg->GetQubitCount(); i++) {
+                               qReg->CNOT(i, (i+1) % qReg->GetQubitCount());
+			}
+		}
+
+		// Last Rotation
+		for (int i = 0; i < qReg->GetQubitCount(); i++) {
+                       qReg->RZ(qReg->Rand(), i);
+                       qReg->RX(qReg->Rand(), i);
+               }
+
+	}
+	state.SetLabel("QCBM");
+}
+
+BENCHMARK(BM_sim_QCBM)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 BENCHMARK_MAIN();

--- a/qrack/benchmarks.cc
+++ b/qrack/benchmarks.cc
@@ -9,12 +9,8 @@ using namespace Qrack;
 auto min_estimator = [](const std::vector<double>& v) -> double {return *(std::min_element(std::begin(v), std::end(v)));};
 
 static void BM_sim_X(benchmark::State& state) {
-	QInterfacePtr qReg = NULL; 
+	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0); 
 	for (auto _ : state){
-		if (qReg != NULL){
-			qReg.reset();
-		}
-		qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 		qReg->X(state.range(0) - 1);
 		qReg->Finish();
 	}
@@ -27,6 +23,7 @@ static void BM_sim_H(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->H(state.range(0) - 1);
+		qReg->Finish();
 	}
 	state.SetLabel("H");
 }
@@ -37,6 +34,7 @@ static void BM_sim_T(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->T(state.range(0) - 1);
+		qReg->Finish();
 	}
 	state.SetLabel("T");
 }
@@ -47,6 +45,7 @@ static void BM_sim_CNOT(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->CNOT(0,1);
+		qReg->Finish();
 	}
 	state.SetLabel("CNOT");
 }
@@ -57,6 +56,7 @@ static void BM_sim_Toffoli(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->CCNOT(0,1,2);
+		qReg->Finish();
 	}
 	state.SetLabel("Toffoli");
 }
@@ -67,6 +67,7 @@ static void BM_sim_Rx(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->RX(0.5, 2);
+		qReg->Finish();
 	}
 	state.SetLabel("Rx");
 }
@@ -77,6 +78,7 @@ static void BM_sim_Ry(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->RY(0.5, 2);
+		qReg->Finish();
 	}
 	state.SetLabel("Ry");
 }

--- a/qrack/benchmarks.cc
+++ b/qrack/benchmarks.cc
@@ -12,8 +12,8 @@ static void BM_sim_X(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0); 
 	for (auto _ : state){
 		qReg->X(state.range(0) - 1);
-		qReg->Finish();
 	}
+	qReg->Finish();
 	state.SetLabel("X");
 }
 // Register the function as a benchmark
@@ -23,8 +23,8 @@ static void BM_sim_H(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->H(state.range(0) - 1);
-		qReg->Finish();
 	}
+	qReg->Finish();
 	state.SetLabel("H");
 }
 // Register the function as a benchmark
@@ -34,8 +34,8 @@ static void BM_sim_T(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->T(state.range(0) - 1);
-		qReg->Finish();
 	}
+	qReg->Finish();
 	state.SetLabel("T");
 }
 // Register the function as a benchmark
@@ -45,8 +45,8 @@ static void BM_sim_CNOT(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->CNOT(0,1);
-		qReg->Finish();
 	}
+	qReg->Finish();
 	state.SetLabel("CNOT");
 }
 // Register the function as a benchmark
@@ -56,8 +56,8 @@ static void BM_sim_Toffoli(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->CCNOT(0,1,2);
-		qReg->Finish();
 	}
+	qReg->Finish();
 	state.SetLabel("Toffoli");
 }
 // Register the function as a benchmark
@@ -67,8 +67,8 @@ static void BM_sim_Rx(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->RX(0.5, 2);
-		qReg->Finish();
 	}
+	qReg->Finish();
 	state.SetLabel("Rx");
 }
 // Register the function as a benchmark
@@ -78,8 +78,8 @@ static void BM_sim_Ry(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->RY(0.5, 2);
-		qReg->Finish();
 	}
+	qReg->Finish();
 	state.SetLabel("Ry");
 }
 // Register the function as a benchmark

--- a/qrack/benchmarks.cc
+++ b/qrack/benchmarks.cc
@@ -23,7 +23,7 @@ static void BM_sim_X(benchmark::State& state) {
 	state.SetLabel("X");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_X)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_X)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_H(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
@@ -34,7 +34,7 @@ static void BM_sim_H(benchmark::State& state) {
 	state.SetLabel("H");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_H)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_H)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_T(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
@@ -45,7 +45,7 @@ static void BM_sim_T(benchmark::State& state) {
 	state.SetLabel("T");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_T)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_T)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_CNOT(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
@@ -56,7 +56,7 @@ static void BM_sim_CNOT(benchmark::State& state) {
 	state.SetLabel("CNOT");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_CNOT)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_CNOT)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Toffoli(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
@@ -67,7 +67,7 @@ static void BM_sim_Toffoli(benchmark::State& state) {
 	state.SetLabel("Toffoli");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_Toffoli)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_Toffoli)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Rx(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
@@ -78,7 +78,7 @@ static void BM_sim_Rx(benchmark::State& state) {
 	state.SetLabel("Rx");
 }
 // Register the function as a benchmark
-BENCHMARK(BM_sim_Rx)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_Rx)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Ry(benchmark::State& state) {
 	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
@@ -90,7 +90,7 @@ static void BM_sim_Ry(benchmark::State& state) {
 }
 
 // Register the function as a benchmark
-BENCHMARK(BM_sim_Ry)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_Ry)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_QCBM(benchmark::State& state) {
         QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
@@ -132,6 +132,6 @@ static void BM_sim_QCBM(benchmark::State& state) {
 	state.SetLabel("QCBM");
 }
 
-BENCHMARK(BM_sim_QCBM)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
+BENCHMARK(BM_sim_QCBM)->DenseRange(4,25)->ComputeStatistics("min", min_estimator);
 
 BENCHMARK_MAIN();

--- a/qrack/benchmarks.cc
+++ b/qrack/benchmarks.cc
@@ -6,10 +6,16 @@
 
 using namespace Qrack; 
 
+// This suite is meant to test "ket" simulation performance specifically,
+// but Qrack can sometimes do much better than this with its default optimal layer stack!
+// Toggle the bool below to try both methods.
+const bool isKet = true;
+const auto SimType = isKet ? QINTERFACE_HYBRID : QINTERFACE_OPTIMAL_MULTI;
+
 auto min_estimator = [](const std::vector<double>& v) -> double {return *(std::min_element(std::begin(v), std::end(v)));};
 
 static void BM_sim_X(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0); 
+	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->X(state.range(0) - 1);
 	}
@@ -20,7 +26,7 @@ static void BM_sim_X(benchmark::State& state) {
 BENCHMARK(BM_sim_X)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_H(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->H(state.range(0) - 1);
 	}
@@ -31,7 +37,7 @@ static void BM_sim_H(benchmark::State& state) {
 BENCHMARK(BM_sim_H)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_T(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->T(state.range(0) - 1);
 	}
@@ -42,7 +48,7 @@ static void BM_sim_T(benchmark::State& state) {
 BENCHMARK(BM_sim_T)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_CNOT(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->CNOT(0,1);
 	}
@@ -53,7 +59,7 @@ static void BM_sim_CNOT(benchmark::State& state) {
 BENCHMARK(BM_sim_CNOT)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Toffoli(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->CCNOT(0,1,2);
 	}
@@ -64,7 +70,7 @@ static void BM_sim_Toffoli(benchmark::State& state) {
 BENCHMARK(BM_sim_Toffoli)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Rx(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->RX(0.5, 2);
 	}
@@ -75,7 +81,7 @@ static void BM_sim_Rx(benchmark::State& state) {
 BENCHMARK(BM_sim_Rx)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Ry(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->RY(0.5, 2);
 	}
@@ -87,7 +93,7 @@ static void BM_sim_Ry(benchmark::State& state) {
 BENCHMARK(BM_sim_Ry)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_QCBM(benchmark::State& state) {
-        QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
+        QInterfacePtr qReg = CreateQuantumInterface({ SimType }, state.range(0), 0);
         for (auto _: state){
 
                // First rotation

--- a/qrack/benchmarks.cc
+++ b/qrack/benchmarks.cc
@@ -14,7 +14,7 @@ static void BM_sim_X(benchmark::State& state) {
 		if (qReg != NULL){
 			qReg.reset();
 		}
-		qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0); 
+		qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 		qReg->X(state.range(0) - 1);
 		qReg->Finish();
 	}
@@ -24,7 +24,7 @@ static void BM_sim_X(benchmark::State& state) {
 BENCHMARK(BM_sim_X)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_H(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->H(state.range(0) - 1);
 	}
@@ -34,7 +34,7 @@ static void BM_sim_H(benchmark::State& state) {
 BENCHMARK(BM_sim_H)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_T(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->T(state.range(0) - 1);
 	}
@@ -44,7 +44,7 @@ static void BM_sim_T(benchmark::State& state) {
 BENCHMARK(BM_sim_T)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_CNOT(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->CNOT(0,1);
 	}
@@ -54,7 +54,7 @@ static void BM_sim_CNOT(benchmark::State& state) {
 BENCHMARK(BM_sim_CNOT)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Toffoli(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->CCNOT(0,1,2);
 	}
@@ -64,7 +64,7 @@ static void BM_sim_Toffoli(benchmark::State& state) {
 BENCHMARK(BM_sim_Toffoli)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Rx(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->RX(0.5, 2);
 	}
@@ -74,7 +74,7 @@ static void BM_sim_Rx(benchmark::State& state) {
 BENCHMARK(BM_sim_Rx)->DenseRange(4,25); //->ComputeStatistics("min", min_estimator);
 
 static void BM_sim_Ry(benchmark::State& state) {
-	QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, state.range(0), 0);
+	QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_HYBRID }, state.range(0), 0);
 	for (auto _ : state){
 		qReg->RY(0.5, 2);
 	}

--- a/qrack/benchmarks.sh
+++ b/qrack/benchmarks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+FILE_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+ROOT_PATH=$(dirname "$FILE_PATH")
+. "$ROOT_PATH/bin/utils/constants.sh"
+
+cd "${FILE_PATH}"
+
+# to restrict the benchmarks to the single gate ones, use --benchmark_filter=BM_sim_[XHTC]
+mkdir -p "$BENCHMARK_DATA_PATH"
+./benchmarks --benchmark_filter=BM_sim_ --benchmark_out_format=json --benchmark_out="$BENCHMARK_DATA_PATH/qrack.json" 

--- a/qrack/setup.sh
+++ b/qrack/setup.sh
@@ -18,7 +18,7 @@ cmake --build "build" --config Release
 
 git clone https://github.com/vm6502q/qrack.git
 cd qrack
-mkdir _build && cd _build && sudo cmake .. && sudo make all install
+mkdir _build && cd _build && sudo cmake .. && sudo make all install -j$(nproc --all)
 cd ${FILE_PATH}
 
 g++ benchmarks.cc -std=c++11 -isystem benchmark/include -Lbuild/src -lbenchmark -lOpenCL -lpthread -lqrack -o benchmarks

--- a/qrack/setup.sh
+++ b/qrack/setup.sh
@@ -7,8 +7,6 @@ BINDIR="$ROOT_PATH/bin"
 
 cd "$FILE_PATH"
 
-echo $(pwd)
-
 # Install Google Benchmark
 # https://github.com/google/benchmark
 rm -rf benchmark qrack
@@ -21,6 +19,6 @@ cmake --build "build" --config Release
 git clone https://github.com/vm6502q/qrack.git
 cd qrack
 mkdir _build && cd _build && sudo cmake -DENABLE_OPENCL=OFF .. && sudo make all install
+cd ${FILE_PATH}
 
-g++ benchmarks.cc -std=c++11 -isystem benchmark/include -Lbuild/src -lbenchmark -lpthread -o benchmarks
-
+g++ benchmarks.cc -std=c++11 -isystem benchmark/include -Lbuild/src -lbenchmark -lpthread -lqrack -o benchmarks

--- a/qrack/setup.sh
+++ b/qrack/setup.sh
@@ -18,7 +18,7 @@ cmake --build "build" --config Release
 
 git clone https://github.com/vm6502q/qrack.git
 cd qrack
-mkdir _build && cd _build && sudo cmake -DENABLE_OPENCL=OFF .. && sudo make all install
+mkdir _build && cd _build && sudo cmake .. && sudo make all install
 cd ${FILE_PATH}
 
-g++ benchmarks.cc -std=c++11 -isystem benchmark/include -Lbuild/src -lbenchmark -lpthread -lqrack -o benchmarks
+g++ benchmarks.cc -std=c++11 -isystem benchmark/include -Lbuild/src -lbenchmark -lOpenCL -lpthread -lqrack -o benchmarks

--- a/qrack/setup.sh
+++ b/qrack/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+FILE_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+ROOT_PATH=`dirname $FILE_PATH`
+BINDIR="$ROOT_PATH/bin"
+. $BINDIR/utils/constants.sh
+
+cd "$FILE_PATH"
+
+echo $(pwd)
+
+# Install Google Benchmark
+# https://github.com/google/benchmark
+rm -rf benchmark qrack
+git clone https://github.com/google/benchmark.git
+
+cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -S benchmark -B "build"
+cmake --build "build" --config Release
+
+
+git clone https://github.com/vm6502q/qrack.git
+cd qrack
+mkdir _build && cd _build && sudo cmake -DENABLE_OPENCL=OFF .. && sudo make all install
+
+g++ benchmarks.cc -std=c++11 -isystem benchmark/include -Lbuild/src -lbenchmark -lpthread -o benchmarks
+


### PR DESCRIPTION
Building upon the work of https://github.com/yardstiq/quantum-benchmarks/pull/24, (with thanks to @codewithsk,) if the comparison is meant to be **strictly ket**, this limits Qrack optimization "layers" to just that, with OpenCL GPU acceleration, hybridized with CPU based ket simulation.