### PR TITLE
 yardstiq/quantum-benchmarks#52: Fix Qrack build

### DIFF
--- a/qrack/setup.sh
+++ b/qrack/setup.sh
@@ -21,4 +21,4 @@ cd qrack
 mkdir _build && cd _build && sudo cmake .. && sudo make all install -j$(nproc --all)
 cd ${FILE_PATH}
 
-g++ benchmarks.cc -std=c++11 -isystem benchmark/include -Lbuild/src -lbenchmark -lOpenCL -lpthread -lqrack -o benchmarks
+g++ benchmarks.cc -std=c++11 -isystem benchmark/include -Ibuild/include -Lbuild/src -lbenchmark -lOpenCL -lpthread -lqrack -o benchmarks


### PR DESCRIPTION
Per issue #52, the header directories have changed for Google's benchmark repository.